### PR TITLE
Make rb-inotify not required in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
   gem 'guard-bundler'
   gem 'guard-puma'
   gem 'guard-sidekiq'
-  gem 'rb-inotify'
+  gem 'rb-inotify', :require => false
   gem 'rubocop'
 end
 


### PR DESCRIPTION
[rb-inotify](https://github.com/nex3/rb-inotify) is linux-specific, so if required by Gemfile, application will not start on OS X.
