### PR TITLE
[WIP] OS X install support

### DIFF
--- a/contrib/bootstrap.sh
+++ b/contrib/bootstrap.sh
@@ -8,8 +8,14 @@ chmod 755 /usr/local/bin/pacapt
 # Upgrade the package database
 pacapt -Sy
 
-# Try to isolate the Docker package, avoiding packages that aren't to do with Linux containers
-docker=$(pacapt -Ss docker | grep -i container | head -1 | awk '{print $1;}')
+# Check OS
+if [[ "$(uname)" == "Darwin" ]]; then
+	# Use boot2docker for OS X
+	docker='boot2docker'
+else
+	# Try to isolate the Docker package, avoiding packages that aren't to do with Linux containers
+	docker=$(pacapt -Ss docker | grep -i container | head -1 | awk '{print $1;}')
+fi
 
 # Install Docker. Crudely bombard the installation with 'y' in case there are any user prompts
 yes | pacapt -S $docker


### PR DESCRIPTION
- [x] Install `boot2docker` when running script on OS X
- [ ] Perform `boot2docker` initialisation in `bootstrap.sh` to get `docker` up and running (https://docs.docker.com/installation/mac/)
- [ ] Check setup is persisted after reboot
- [ ] Maybe also install `wget` at the start of `bootstrap.sh` for OS X, as it doesn't ship with it